### PR TITLE
Add spaces list view

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,45 +1,20 @@
-import { Board } from './Board.js'
-import { Sidebar } from './Sidebar.js'
-import { uploadImage } from '../lib/upload-image.js'
-import { useDocState } from '../hooks/useDocState.js'
-import { ImageDrop } from './ImageDrop.js'
-import { useInitApp } from '../hooks/useInitApp.js'
 import { useSession } from '@supabase/auth-helpers-react'
 import { Auth } from './Auth.js'
+import { Spaces } from './Spaces.js'
+import { Editor } from './Editor.js'
+import { getUrlId } from '../lib/url.js'
 
 export function App() {
   const session = useSession()
-  const state = useDocState()
-  const { doc, onNodeCreate, onNodeDelete, onNodeUpdate, onConnect, onDisconnect, onBackgroundColorChange } = state
-  const { onLockChange, onTitleChange } = useInitApp(state)
+  const id = getUrlId()
 
   if (!session) {
     return <Auth />
   }
 
-  return (
-    <ImageDrop
-      onNodeCreate={onNodeCreate}
-      onNodeDelete={onNodeDelete}
-      onNodeUpdate={onNodeUpdate}
-      uploadImage={uploadImage}
-    >
-      <Board
-        {...doc}
-        onNodeCreate={onNodeCreate}
-        onNodeDelete={onNodeDelete}
-        onNodeUpdate={onNodeUpdate}
-        onConnect={onConnect}
-        onDisconnect={onDisconnect}
-        onBackgroundColorChange={onBackgroundColorChange}
-      />
+  if (!id) {
+    return <Spaces />
+  }
 
-      <Sidebar
-        onLockChange={onLockChange}
-        onTitleChange={onTitleChange}
-        isLocked={doc.isLocked}
-        title={doc.title}
-      />
-    </ImageDrop>
-  )
+  return <Editor />
 }

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,0 +1,38 @@
+import { Board } from './Board.js'
+import { Sidebar } from './Sidebar.js'
+import { uploadImage } from '../lib/upload-image.js'
+import { useDocState } from '../hooks/useDocState.js'
+import { ImageDrop } from './ImageDrop.js'
+import { useInitApp } from '../hooks/useInitApp.js'
+
+export function Editor() {
+  const state = useDocState()
+  const { doc, onNodeCreate, onNodeDelete, onNodeUpdate, onConnect, onDisconnect, onBackgroundColorChange } = state
+  const { onLockChange, onTitleChange } = useInitApp(state)
+
+  return (
+    <ImageDrop
+      onNodeCreate={onNodeCreate}
+      onNodeDelete={onNodeDelete}
+      onNodeUpdate={onNodeUpdate}
+      uploadImage={uploadImage}
+    >
+      <Board
+        {...doc}
+        onNodeCreate={onNodeCreate}
+        onNodeDelete={onNodeDelete}
+        onNodeUpdate={onNodeUpdate}
+        onConnect={onConnect}
+        onDisconnect={onDisconnect}
+        onBackgroundColorChange={onBackgroundColorChange}
+      />
+
+      <Sidebar
+        onLockChange={onLockChange}
+        onTitleChange={onTitleChange}
+        isLocked={doc.isLocked}
+        title={doc.title}
+      />
+    </ImageDrop>
+  )
+}

--- a/src/components/Spaces.tsx
+++ b/src/components/Spaces.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useMemo, useState } from 'react'
+import { makeUrl } from '../lib/url.js'
+import { randomId } from '../lib/utils.js'
+import { listDocs } from '../lib/dinky-api.js'
+
+export type SpaceInfo = { id: string; title?: string }
+
+export function Spaces() {
+  const [spaces, setSpaces] = useState<SpaceInfo[]>([])
+
+  useEffect(() => {
+    listDocs()
+      .then((list) => setSpaces(list))
+      .catch((err) => console.error('Error loading spaces', err))
+  }, [])
+
+  const newId = useMemo(() => randomId(), [])
+
+  return (
+    <div className="Spaces">
+      <div className="Spaces_grid">
+        <a className="SpaceCard SpaceCard_new" href={makeUrl(newId)}>
+          ＋ New space
+        </a>
+        {spaces.map((space) => (
+          <a
+            key={space.id}
+            className="SpaceCard"
+            href={makeUrl(space.id, space.title)}
+          >
+            {space.title || 'Untitled'}
+          </a>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/dinky-api.ts
+++ b/src/lib/dinky-api.ts
@@ -102,3 +102,20 @@ export async function saveDoc(data: DinkyDataV2, password?: string) {
   }
   return { status: 200, key: data.id }
 }
+export type SpaceMeta = { id: string; title?: string }
+
+export async function listDocs(): Promise<SpaceMeta[]> {
+  const { data, error } = await supabase.from('documents').select('id, data')
+
+  if (error || !data) {
+    throw error || new Error('Unable to load documents')
+  }
+  return data.map((row: { id: string; data: string }) => {
+    try {
+      const parsed = JSON.parse(row.data)
+      return { id: row.id, title: parsed.title } as SpaceMeta
+    } catch {
+      return { id: row.id } as SpaceMeta
+    }
+  })
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -521,3 +521,35 @@ button.Sidebar_button {
   margin: 0 20px;
   cursor: pointer;
 }
+
+.Spaces {
+  padding: 20px;
+}
+
+.Spaces_grid {
+  margin: 0 auto;
+  max-width: 1000px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 20px;
+}
+
+.SpaceCard {
+  background: var(--card-color);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 20px;
+  text-align: center;
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+.SpaceCard:hover {
+  background: var(--card-hover-color);
+}
+
+.SpaceCard_new {
+  font-size: 20px;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- route to login, spaces list, or editor depending on URL
- split board into `Editor` component
- implement `Spaces` component for listing user documents
- query Supabase for docs
- style new spaces view
- switch space cards to anchor links

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_685d7ffcdadc832fa9aa3414acabf05a