### PR TITLE
Add shared header/footer components

### DIFF
--- a/src/components/AuthView.tsx
+++ b/src/components/AuthView.tsx
@@ -1,0 +1,12 @@
+import { Header } from './Header.js'
+import { Footer } from './Footer.js'
+
+export function AuthView() {
+  return (
+    <div className="AuthView">
+      <Header />
+      <main className="AuthView_content" />
+      <Footer />
+    </div>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,9 @@
+import { InfoLinks } from './InfoLinks.js'
+
+export function Footer() {
+  return (
+    <footer className="Footer">
+      <InfoLinks direction="row" />
+    </footer>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react'
+
+type HeaderProps = {
+  showLogout?: boolean
+  onLogout?: () => void
+  children?: ReactNode
+}
+
+export function Header({ showLogout, onLogout, children }: HeaderProps) {
+  return (
+    <header className="Header">
+      <img src="/dinky-small.png" alt="SpaceNotes" />
+      <h1>SpaceNotes</h1>
+      {children}
+      {showLogout && (
+        <button className="Header_logout" onClick={onLogout}>
+          Log out
+        </button>
+      )}
+    </header>
+  )
+}

--- a/src/components/InfoLinks.tsx
+++ b/src/components/InfoLinks.tsx
@@ -1,0 +1,24 @@
+import { makeUrl } from '../lib/url.js'
+
+const infoLinks = [
+  { title: 'About', url: makeUrl('about-9315ba924c9d16e632145116d69ae72a') },
+  { title: 'Privacy', url: makeUrl('074505b43d5c0b97', 'privacy') },
+  { title: 'Terms', url: makeUrl('43a7a9fa13bb3d0c', 'terms') },
+  { title: 'GitHub', url: 'https://github.com/katspaugh/dinky.dog' },
+]
+
+type InfoLinksProps = {
+  direction?: 'row' | 'column'
+}
+
+export function InfoLinks({ direction = 'column' }: InfoLinksProps) {
+  return (
+    <ul className={`InfoLinks InfoLinks_${direction}`}>
+      {infoLinks.map((link) => (
+        <li key={link.url}>
+          <a href={link.url}>{link.title}</a>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,13 +2,8 @@ import { useCallback, useEffect, useState } from 'react'
 import { getSavedStates } from '../lib/persist.js'
 import { makeUrl } from '../lib/url.js'
 import { LockButton } from './LockButton.js'
+import { InfoLinks } from './InfoLinks.js'
 
-const fixedLinks = [
-  { title: 'About', url: makeUrl('about-9315ba924c9d16e632145116d69ae72a') },
-  { title: 'Privacy', url: makeUrl('074505b43d5c0b97', 'privacy') },
-  { title: 'Terms', url: makeUrl('43a7a9fa13bb3d0c', 'terms') },
-  { title: 'GitHub', url: 'https://github.com/katspaugh/dinky.dog' },
-]
 
 type SidebarProps = {
   isLocked?: boolean
@@ -94,9 +89,7 @@ export function Sidebar({ isLocked, title, onLockChange, onTitleChange }: Sideba
 
         {divider}
 
-        <ul>
-          {fixedLinks.map(renderLink)}
-        </ul>
+        <InfoLinks direction="column" />
       </div>
     </aside>
   )

--- a/src/components/SpacesView.tsx
+++ b/src/components/SpacesView.tsx
@@ -1,0 +1,18 @@
+import { Header } from './Header.js'
+import { Footer } from './Footer.js'
+import { clear } from '../lib/local-storage.js'
+
+export function SpacesView() {
+  const onLogout = () => {
+    clear()
+    window.location.href = '/'
+  }
+
+  return (
+    <div className="SpacesView">
+      <Header showLogout onLogout={onLogout} />
+      <main className="SpacesView_content" />
+      <Footer />
+    </div>
+  )
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -487,3 +487,72 @@ button.Sidebar_button {
 .Drop__dragover {
   background: rgba(100, 0, 100, 0.1);
 }
+
+.Header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 20px;
+  background: var(--menu-background-color);
+  color: var(--menu-text-color);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.Header h1 {
+  flex: 1;
+  font-size: 24px;
+  margin: 0;
+}
+
+.Header img {
+  width: 32px;
+  height: 32px;
+}
+
+.Header_logout {
+  background: var(--button-color);
+  border: 1px solid var(--button-border-color);
+  border-radius: 8px;
+  padding: 0.5em 1em;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.Footer {
+  background: var(--menu-background-color);
+  color: var(--menu-text-color);
+  padding: 20px;
+  text-align: center;
+  border-top: 1px solid var(--border-color);
+}
+
+.InfoLinks {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 10px;
+}
+
+.InfoLinks_column {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.InfoLinks_row {
+  flex-direction: row;
+  justify-content: center;
+}
+
+.InfoLinks li a {
+  display: block;
+  padding: 10px;
+  color: var(--menu-text-color);
+  text-decoration: none;
+  border-radius: 6px;
+}
+
+.InfoLinks li a:hover {
+  background: var(--menu-hover-color);
+  color: var(--menu-hover-text-color);
+}


### PR DESCRIPTION
## Summary
- create reusable `Header`/`Footer` pieces
- share About/Privacy/Terms/GitHub via `InfoLinks`
- restore original view routing

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_b_685d848e85e8832f99bac163833e1350