### PR TITLE
Update privacy policy for Supabase authentication

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -4,19 +4,19 @@ Effective Date: 26.06.2025
 Welcome to SpaceNotes. We respect your privacy and are committed to protecting your personal data. This Privacy Policy will inform you about how we handle your data when you visit our website, regardless of where you visit it from, and tell you about your privacy rights and how the law protects you.
 
 <h2>1. Information We Collect</h2>
-At SpaceNotes, we currently do not collect personal data directly. However, when you use our service to share content or view external link previews, certain indirect information may be collected by the previewed external resources, including:
+We collect your email address to authenticate you when you sign in. Your documents and account information are stored on Supabase along with your email. When you use our service to share content or view external link previews, certain indirect information may also be collected by the previewed external resources, including:
 External Link Previews: When you paste an external link on SpaceNotes, we fetch a preview of that link, which may include images. These images are hot-loaded from that external site, which means that your IP address may be shared with that site each time the content is viewed.
 
 <h2>2. How We Use Your Information</h2>
-Since we do not collect personal data, our use of information is limited to the provision of the service - enabling content sharing and real-time collaboration on our platform.
+We use your email solely to authenticate you and to associate your documents with your account. This information is stored on Supabase. We also use indirect information to provide link previews and enable content sharing and real-time collaboration on our platform.
 
 <h2>3. Data Storage and Security</h2>
-All content created and shared on SpaceNotes is stored unencrypted on CloudFlare servers. While we strive to protect your content, we do not authenticate the data or the users sharing or editing the content. Anyone with a link to the content can view and potentially edit shared content.
+All content you create and your account details are stored unencrypted on Supabase servers. We authenticate users through Supabase using their email address. Documents you share with others may be viewed and edited by anyone with the link.
 
-Shared content can be collaboratively edited in real-time. Peer editing is not authenticated, and all changes are immediately visible to all users with access to the content. Peers can see the browser name and color of the cursor of other users editing the content.
+Shared content can be collaboratively edited in real-time. All changes are immediately visible to users with whom you have shared the document. Peers can see the browser name and color of the cursor of other users editing the content.
 
 <h2>4. Your Rights</h2>
-As we do not collect personal data, the scope of your rights under data protection laws is limited in the context of our service. However, should this change in the future, we will update our policy accordingly and inform you of your rights and how to exercise them.
+You may request access to or deletion of the personal data we store about you, including your email address and documents saved in Supabase. Please contact us if you wish to exercise these rights.
 
 <h2>5. Changes to This Policy</h2>
 We may update this Privacy Policy from time to time. We will notify you of any changes by posting an update.


### PR DESCRIPTION
## Summary
- reflect that SpaceNotes authenticates by email
- clarify that user data is stored on Supabase

## Testing
- `yarn lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d902e4e68832f96c42059d8767c8f