### PR TITLE
Add view wrappers with shared header and footer

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,7 @@
 import { useSession } from '@supabase/auth-helpers-react'
-import { Auth } from './Auth.js'
-import { Spaces } from './Spaces.js'
-import { Editor } from './Editor.js'
+import { AuthView } from './AuthView.js'
+import { SpacesView } from './SpacesView.js'
+import { EditorView } from './EditorView.js'
 import { getUrlId } from '../lib/url.js'
 
 export function App() {
@@ -9,12 +9,12 @@ export function App() {
   const id = getUrlId()
 
   if (!session) {
-    return <Auth />
+    return <AuthView />
   }
 
   if (!id) {
-    return <Spaces />
+    return <SpacesView />
   }
 
-  return <Editor />
+  return <EditorView />
 }

--- a/src/components/AuthView.tsx
+++ b/src/components/AuthView.tsx
@@ -1,0 +1,13 @@
+import { Auth } from './Auth.js'
+import { Header } from './Header.js'
+import { Footer } from './Footer.js'
+
+export function AuthView() {
+  return (
+    <div className="AuthView">
+      <Header />
+      <Auth />
+      <Footer />
+    </div>
+  )
+}

--- a/src/components/EditorView.tsx
+++ b/src/components/EditorView.tsx
@@ -1,0 +1,5 @@
+import { Editor } from './Editor.js'
+
+export function EditorView() {
+  return <Editor />
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,9 @@
+import { Links } from './Links.js'
+
+export function Footer() {
+  return (
+    <footer className="Footer">
+      <Links direction="row" />
+    </footer>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,19 @@
+import { supabase } from '../lib/supabase.js'
+
+export function Header({ showLogout = false }: { showLogout?: boolean }) {
+  const onSignOut = () => {
+    supabase.auth.signOut()
+  }
+
+  return (
+    <header className="Header">
+      <img src="/logo.png" alt="SpaceNotes" />
+      <h1>SpaceNotes</h1>
+      {showLogout && (
+        <button className="Header_logout" onClick={onSignOut}>
+          Log out
+        </button>
+      )}
+    </header>
+  )
+}

--- a/src/components/Links.tsx
+++ b/src/components/Links.tsx
@@ -1,9 +1,7 @@
-import { makeUrl } from '../lib/url.js'
-
 export const links = [
-  { title: 'About', url: makeUrl('about-9315ba924c9d16e632145116d69ae72a') },
-  { title: 'Privacy', url: makeUrl('074505b43d5c0b97', 'privacy') },
-  { title: 'Terms', url: makeUrl('43a7a9fa13bb3d0c', 'terms') },
+  { title: 'About', url: '/about.html' },
+  { title: 'Privacy', url: '/privacy.html' },
+  { title: 'Terms', url: '/terms.html') },
   { title: 'GitHub', url: 'https://github.com/katspaugh/dinky.dog' },
 ]
 

--- a/src/components/Links.tsx
+++ b/src/components/Links.tsx
@@ -1,0 +1,20 @@
+import { makeUrl } from '../lib/url.js'
+
+export const links = [
+  { title: 'About', url: makeUrl('about-9315ba924c9d16e632145116d69ae72a') },
+  { title: 'Privacy', url: makeUrl('074505b43d5c0b97', 'privacy') },
+  { title: 'Terms', url: makeUrl('43a7a9fa13bb3d0c', 'terms') },
+  { title: 'GitHub', url: 'https://github.com/katspaugh/dinky.dog' },
+]
+
+export function Links({ direction = 'row', className = '' }: { direction?: 'row' | 'column'; className?: string }) {
+  return (
+    <ul className={`Links Links_${direction} ${className}`.trim()}>
+      {links.map((link) => (
+        <li key={link.url}>
+          <a href={link.url}>{link.title}</a>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,13 +3,7 @@ import { makeUrl } from '../lib/url.js'
 import { LockButton } from './LockButton.js'
 import { supabase } from '../lib/supabase.js'
 import { listDocs } from '../lib/dinky-api.js'
-
-const fixedLinks = [
-  { title: 'About', url: makeUrl('about-9315ba924c9d16e632145116d69ae72a') },
-  { title: 'Privacy', url: makeUrl('074505b43d5c0b97', 'privacy') },
-  { title: 'Terms', url: makeUrl('43a7a9fa13bb3d0c', 'terms') },
-  { title: 'GitHub', url: 'https://github.com/katspaugh/dinky.dog' },
-]
+import { Links } from './Links.js'
 
 type SidebarProps = {
   isLocked?: boolean
@@ -102,9 +96,7 @@ export function Sidebar({ isLocked, title, onLockChange, onTitleChange }: Sideba
 
         {divider}
 
-        <ul>
-          {fixedLinks.map(renderLink)}
-        </ul>
+        <Links direction="column" />
 
         <button className="Sidebar_logout" onClick={onSignOut}>Sign out</button>
       </div>

--- a/src/components/SpacesView.tsx
+++ b/src/components/SpacesView.tsx
@@ -1,0 +1,13 @@
+import { Spaces } from './Spaces.js'
+import { Header } from './Header.js'
+import { Footer } from './Footer.js'
+
+export function SpacesView() {
+  return (
+    <div className="SpacesView">
+      <Header showLogout />
+      <Spaces />
+      <Footer />
+    </div>
+  )
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -555,3 +555,41 @@ button.Sidebar_button {
   font-size: 20px;
   font-weight: bold;
 }
+
+/* Layout */
+.Header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 20px;
+}
+
+.Header h1 {
+  margin: 0;
+  flex: 1;
+}
+
+.Header_logout {
+  background: var(--button-color);
+  border: 1px solid var(--button-border-color);
+  border-radius: 8px;
+  padding: 0.5em 1em;
+  cursor: pointer;
+}
+
+.Footer {
+  text-align: center;
+  padding: 20px;
+}
+
+.Links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.Links_row {
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+}


### PR DESCRIPTION
## Summary
- create `AuthView`, `SpacesView` and `EditorView`
- add `Header` and `Footer` components
- extract common info links into new `Links` component
- use the header and footer in Auth and Spaces views
- update sidebar to reuse the links component
- style header, footer and links

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_b_685d939c160c832f921ba8da39c9678a