### PR TITLE
Improve auth UX

### DIFF
--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -6,17 +6,30 @@ export function Auth() {
   const [password, setPassword] = useState('')
   const [isSignUp, setIsSignUp] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null)
+    setMessage(null)
+    setLoading(true)
     if (isSignUp) {
       const { error } = await supabase.auth.signUp({ email, password })
       if (error) setError(error.message)
+      else setMessage('Check your email to confirm sign up')
     } else {
       const { error } = await supabase.auth.signInWithPassword({ email, password })
       if (error) setError(error.message)
+      else setMessage('Signed in!')
     }
+    setLoading(false)
+  }
+
+  const toggleMode = () => {
+    setIsSignUp(!isSignUp)
+    setError(null)
+    setMessage(null)
   }
 
   return (
@@ -35,9 +48,18 @@ export function Auth() {
         onChange={(e) => setPassword(e.target.value)}
         required
       />
+      {loading && <div className="Auth_loader">Loading…</div>}
+      {message && <div className="Auth_message">{message}</div>}
       {error && <div className="Auth_error">{error}</div>}
-      <button type="submit">{isSignUp ? 'Sign up' : 'Sign in'}</button>
-      <button type="button" onClick={() => setIsSignUp(!isSignUp)}>
+      <button type="submit" disabled={loading}>
+        {isSignUp ? 'Sign up' : 'Sign in'}
+      </button>
+      <button
+        type="button"
+        className="Auth_textButton"
+        onClick={toggleMode}
+        disabled={loading}
+      >
         {isSignUp ? 'Have an account? Sign in' : 'Need an account? Sign up'}
       </button>
     </form>

--- a/src/components/Links.tsx
+++ b/src/components/Links.tsx
@@ -1,7 +1,7 @@
 export const links = [
   { title: 'About', url: '/about.html' },
   { title: 'Privacy', url: '/privacy.html' },
-  { title: 'Terms', url: '/terms.html') },
+  { title: 'Terms', url: '/terms.html' },
   { title: 'GitHub', url: 'https://github.com/katspaugh/dinky.dog' },
 ]
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -511,6 +511,27 @@ button.Sidebar_button {
   cursor: pointer;
 }
 
+.Auth button[disabled] {
+  cursor: not-allowed;
+}
+
+.Auth_textButton {
+  background: none;
+  border: none;
+  color: var(--accent-color);
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.Auth_loader {
+  text-align: center;
+}
+
+.Auth_message {
+  color: green;
+}
+
 .Auth_error {
   color: red;
 }


### PR DESCRIPTION
## Summary
- provide loader and message states in the auth form
- add success notice on sign up/sign in
- replace secondary CTA with a text button
- add styles for loader, text button and messages
- fix typo in `Links.tsx`

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_685d965090c8832f881edf2c077f6ee0