### PR TITLE
Add delete space feature

### DIFF
--- a/src/components/Spaces.tsx
+++ b/src/components/Spaces.tsx
@@ -1,12 +1,22 @@
 import { useEffect, useMemo, useState } from 'react'
 import { makeUrl } from '../lib/url.js'
 import { randomId } from '../lib/utils.js'
-import { listDocs } from '../lib/dinky-api.js'
+import { listDocs, deleteDoc } from '../lib/dinky-api.js'
 
 export type SpaceInfo = { id: string; title?: string }
 
 export function Spaces() {
   const [spaces, setSpaces] = useState<SpaceInfo[]>([])
+
+  const onDelete = async (id: string) => {
+    if (!confirm('Delete this space?')) return
+    try {
+      await deleteDoc(id)
+      setSpaces((old) => old.filter((s) => s.id !== id))
+    } catch (err) {
+      console.error('Error deleting space', err)
+    }
+  }
 
   useEffect(() => {
     listDocs()
@@ -23,13 +33,18 @@ export function Spaces() {
           ＋ New space
         </a>
         {spaces.map((space) => (
-          <a
-            key={space.id}
-            className="SpaceCard"
-            href={makeUrl(space.id, space.title)}
-          >
-            {space.title || 'Untitled'}
-          </a>
+          <div key={space.id} className="SpaceCardWrapper">
+            <a className="SpaceCard" href={makeUrl(space.id, space.title)}>
+              {space.title || 'Untitled'}
+            </a>
+            <button
+              type="button"
+              className="SpaceCard_delete"
+              onClick={() => onDelete(space.id)}
+            >
+              ×
+            </button>
+          </div>
         ))}
       </div>
     </div>

--- a/src/lib/dinky-api.ts
+++ b/src/lib/dinky-api.ts
@@ -89,3 +89,10 @@ export async function listDocs(): Promise<SpaceMeta[]> {
     }
   })
 }
+
+export async function deleteDoc(id: string) {
+  const { error } = await supabase.from('documents').delete().eq('id', id)
+  if (error) {
+    throw error
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -637,6 +637,27 @@ button.Auth_textButton {
   font-weight: bold;
 }
 
+.SpaceCardWrapper {
+  position: relative;
+}
+
+.SpaceCard_delete {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  border: none;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0;
+}
+
+.SpaceCard_delete:hover {
+  color: var(--color-text);
+}
+
 /* Layout */
 .Header {
   display: flex;


### PR DESCRIPTION
## Summary
- support deleting documents via API
- add delete buttons to space cards
- style delete buttons and wrappers

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_685e432cf600832fb78cd5e8b5a6f5c8