### PR TITLE
Add pagination to Spaces view

### DIFF
--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -26,3 +26,15 @@ export function setUrlId(id: string, title?: string) {
 export function makeUrl(id: string, title?: string) {
   return `${window.location.origin}/?q=${encodeURIComponent(addPrefix(id, title))}`
 }
+
+export function getUrlPage() {
+  const url = new URL(window.location.href)
+  const p = parseInt(url.searchParams.get('page') || '1', 10)
+  return Number.isFinite(p) && p > 0 ? p : 1
+}
+
+export function setUrlPage(page: number) {
+  const url = new URL(window.location.href)
+  url.searchParams.set('page', String(page))
+  window.history.replaceState({}, '', url.toString())
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -618,6 +618,27 @@ button.Auth_textButton {
   gap: var(--space-l);
 }
 
+.Spaces_pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--space-m);
+  margin-top: var(--space-l);
+}
+
+.Spaces_pagination button {
+  padding: var(--space-s) var(--space-m);
+  border: 1px solid var(--border-color);
+  background: var(--color-surface);
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.Spaces_pagination button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .SpaceCard {
   display: block;
   width: 100%;


### PR DESCRIPTION
## Summary
- implement get/set page helpers
- paginate spaces list with prev/next controls
- style pagination controls

## Testing
- `git status --short`
- `git log -1 --stat`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_685e4baac47c832f9c6aec5fbb5d20bf