### PR TITLE
Implement infinite scroll in sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { makeUrl } from '../lib/url.js'
 import { LockButton } from './LockButton.js'
 import { supabase } from '../lib/supabase.js'
@@ -19,16 +19,20 @@ export function Sidebar({ isLocked, title, onLockChange, onTitleChange }: Sideba
   const [docs, setDocs] = useState([])
   const [page, setPage] = useState(1)
   const [totalPages, setTotalPages] = useState(1)
+  const [isLoading, setIsLoading] = useState(false)
+  const listRef = useRef<HTMLUListElement>(null)
 
   const loadDocs = useCallback(async (p: number) => {
     try {
+      setIsLoading(true)
       const { spaces, total } = await listDocsPage(p, ITEMS_PER_PAGE)
       const pages = Math.max(1, Math.ceil(total / ITEMS_PER_PAGE))
-      setDocs(spaces)
+      setDocs((prev) => (p === 1 ? spaces : [...prev, ...spaces]))
       setTotalPages(pages)
-      if (p > pages) setPage(pages)
     } catch (err) {
       console.error('Error loading spaces', err)
+    } finally {
+      setIsLoading(false)
     }
   }, [])
 
@@ -55,6 +59,18 @@ export function Sidebar({ isLocked, title, onLockChange, onTitleChange }: Sideba
     onTitleChange(value)
   }, [onTitleChange])
 
+  const onScroll = useCallback(() => {
+    const list = listRef.current
+    if (
+      list &&
+      !isLoading &&
+      page < totalPages &&
+      list.scrollHeight - list.scrollTop - list.clientHeight < 50
+    ) {
+      setPage((p) => p + 1)
+    }
+  }, [isLoading, page, totalPages])
+
   const toggleButton = (
     <button className="Sidebar_toggle" onClick={toggleDrawer} />
   )
@@ -70,6 +86,13 @@ export function Sidebar({ isLocked, title, onLockChange, onTitleChange }: Sideba
       document.body.removeEventListener('click', onClickOutside)
     }
   }, [])
+
+  useEffect(() => {
+    if (isOpen) {
+      setDocs([])
+      setPage(1)
+    }
+  }, [isOpen])
 
   useEffect(() => {
     if (isOpen) {
@@ -106,21 +129,10 @@ export function Sidebar({ isLocked, title, onLockChange, onTitleChange }: Sideba
           {renderLink({ url: makeUrl(Math.random().toString(36).slice(2)), title: '＋New' })}
         </ul>
 
-        <ul className="Sidebar_links">
+        <ul className="Sidebar_links" ref={listRef} onScroll={onScroll}>
           {docs.map((doc) => renderLink({ url: makeUrl(doc.id, doc.title), title: doc.title }))}
+          {isLoading && <li className="Sidebar_loader">Loading…</li>}
         </ul>
-
-        {totalPages > 1 && (
-          <div className="Sidebar_pagination">
-            <button type="button" onClick={() => setPage(page - 1)} disabled={page <= 1}>
-              Previous
-            </button>
-            <span>{page} / {totalPages}</span>
-            <button type="button" onClick={() => setPage(page + 1)} disabled={page >= totalPages}>
-              Next
-            </button>
-          </div>
-        )}
 
         {divider}
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -500,25 +500,9 @@ button.Sidebar_toggle:hover {
   padding: 0;
 }
 
-.Sidebar_pagination {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: var(--space-s);
+.Sidebar_loader {
+  text-align: center;
   padding: var(--space-s) var(--space-l);
-}
-
-.Sidebar_pagination button {
-  padding: var(--space-s) var(--space-m);
-  border: 1px solid var(--border-color);
-  background: var(--color-surface);
-  border-radius: var(--radius);
-  cursor: pointer;
-}
-
-.Sidebar_pagination button:disabled {
-  opacity: 0.5;
-  cursor: default;
 }
 
 .SelectionBox {


### PR DESCRIPTION
## Summary
- support infinite scrolling in `Sidebar` document list
- show loading indicator while fetching more pages
- remove old pagination styles

## Testing
- `yarn lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685faeef8078832fa99704197e48af35