### PR TITLE
Fix sidebar when logged out

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -84,6 +84,10 @@ export function Sidebar({ isLocked, title, onFork, onTitleChange }: SidebarProps
     supabase.auth.signOut()
   }, [])
 
+  const onSignIn = useCallback(() => {
+    window.location.href = '/'
+  }, [])
+
   return (
     <aside className={`Sidebar${isLocked ? ' Sidebar_locked' : ''}`}>
       <input onInput={onInput} value={title ?? ''} />
@@ -102,7 +106,13 @@ export function Sidebar({ isLocked, title, onFork, onTitleChange }: SidebarProps
         {divider}
 
         <div className="Sidebar_actions">
-          <ForkButton onFork={onFork} />
+          {userId ? (
+            <ForkButton onFork={onFork} />
+          ) : (
+            <button className="Sidebar_signin" onClick={onSignIn}>
+              Sign in / Sign up
+            </button>
+          )}
         </div>
 
         <ul>
@@ -129,7 +139,11 @@ export function Sidebar({ isLocked, title, onFork, onTitleChange }: SidebarProps
 
         <Links direction="column" />
 
-        <button className="Sidebar_logout" onClick={onSignOut}>Sign out</button>
+        {userId && (
+          <button className="Sidebar_logout" onClick={onSignOut}>
+            Sign out
+          </button>
+        )}
       </div>
     </aside>
   )

--- a/src/styles.css
+++ b/src/styles.css
@@ -625,6 +625,10 @@ button.Auth_textButton {
   margin: 0 var(--space-l);
 }
 
+.Sidebar_signin {
+  margin: 0 var(--space-l);
+}
+
 .Spaces {
   padding: var(--space-l);
 }


### PR DESCRIPTION
## Summary
- ensure Sidebar shows sign-in button when there's no session
- hide Fork and Sign out when logged out
- add basic style for Sidebar sign-in

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_686026791258832f8eb9b4551919d333