### PR TITLE
Highlight active space

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { makeUrl } from '../lib/url.js'
+import { makeUrl, getUrlId } from '../lib/url.js'
 import { ForkButton } from './ForkButton.js'
 import { supabase } from '../lib/supabase.js'
 import { listDocsPage } from '../lib/dinky-api.js'
@@ -22,6 +22,7 @@ export function Sidebar({ isLocked, title, onFork, onTitleChange }: SidebarProps
   const [totalPages, setTotalPages] = useState(1)
   const session = useSession()
   const userId = session?.user?.id || ''
+  const currentId = getUrlId()
 
   const loadDocs = useCallback(async (p: number) => {
     try {
@@ -43,14 +44,18 @@ export function Sidebar({ isLocked, title, onFork, onTitleChange }: SidebarProps
   const stopPropagation = useCallback((e) => e.stopPropagation(), [])
 
   const renderLink = useCallback(
-    (doc) => (
+    (doc: { id?: string; url: string; title?: string }) => (
       <li key={doc.url}>
-        <a href={doc.url}>
-          {doc.title}
-        </a>
+        {doc.id && doc.id === currentId ? (
+          <strong className="Sidebar_current">{doc.title}</strong>
+        ) : (
+          <a href={doc.url}>
+            {doc.title}
+          </a>
+        )}
       </li>
     ),
-    [],
+    [currentId],
   )
 
   const onInput = useCallback((e) => {
@@ -110,7 +115,7 @@ export function Sidebar({ isLocked, title, onFork, onTitleChange }: SidebarProps
         </ul>
 
         <ul className="Sidebar_links">
-          {docs.map((doc) => renderLink({ url: makeUrl(doc.id, doc.title), title: doc.title }))}
+          {docs.map((doc) => renderLink({ id: doc.id, url: makeUrl(doc.id, doc.title), title: doc.title }))}
         </ul>
 
         {totalPages > 1 && (

--- a/src/styles.css
+++ b/src/styles.css
@@ -490,6 +490,17 @@ button.Sidebar_toggle:hover {
   text-overflow: ellipsis;
 }
 
+.Sidebar_current {
+  display: block;
+  padding: var(--space-s) var(--space-s);
+  font-weight: bold;
+  color: var(--menu-text-color);
+  border-radius: var(--radius);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .Sidebar li a:hover {
   background: var(--menu-hover-color);
   color: var(--menu-hover-text-color);


### PR DESCRIPTION
## Summary
- show active space id via `getUrlId`
- replace sidebar link with bold text when viewing that space
- style active space entry

## Testing
- `yarn lint`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_68602688696c832fae926a42806e4a4f