### PR TITLE
Fix duplicate cursor on refresh

### DIFF
--- a/src/hooks/useRealtimeChannel.ts
+++ b/src/hooks/useRealtimeChannel.ts
@@ -4,6 +4,17 @@ import { randomId } from '../lib/utils.js'
 import type { CanvasNode, CanvasEdge } from '../types/canvas.js'
 import type { RealtimeChannel } from '@supabase/supabase-js'
 
+const CLIENT_ID_KEY = 'spacenotes-client-id'
+
+function getClientId() {
+  let id = sessionStorage.getItem(CLIENT_ID_KEY)
+  if (!id) {
+    id = randomId()
+    sessionStorage.setItem(CLIENT_ID_KEY, id)
+  }
+  return id
+}
+
 export type RealtimeAction =
   | { type: 'node:create'; node: CanvasNode }
   | { type: 'node:update'; id: string; props: Partial<CanvasNode> }
@@ -19,7 +30,7 @@ export function useRealtimeChannel(
   handlers: { apply: (action: RealtimeAction, clientId: string) => void },
 ) {
   const channelRef = useRef<RealtimeChannel | null>(null)
-  const clientId = useRef(randomId())
+  const clientId = useRef(getClientId())
 
   useEffect(() => {
     if (!docId) return


### PR DESCRIPTION
## Summary
- persist realtime `clientId` between page refreshes by storing it in `sessionStorage`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686035f080d4832f83d02415d5153b07