### PR TITLE
Improve realtime node translation

### DIFF
--- a/src/hooks/useRealtimeDocState.ts
+++ b/src/hooks/useRealtimeDocState.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef, useState, useEffect } from 'react'
 import type { CanvasNode } from '../types/canvas.js'
 import { useDocState } from './useDocState.js'
 import { useRealtimeChannel, type RealtimeAction } from './useRealtimeChannel.js'
-import { debounce, randomId, randomBrightColor } from '../lib/utils.js'
+import { debounce, randomId, randomBrightColor, throttleTranslate } from '../lib/utils.js'
 import { supabase } from '../lib/supabase.js'
 import { loadDoc } from '../lib/dinky-api.js'
 
@@ -101,7 +101,7 @@ export function useRealtimeDocState() {
   )
 
   const sendMove = useRef(
-    debounce((id: string, dx: number, dy: number) => {
+    throttleTranslate((id: string, dx: number, dy: number) => {
       send({ type: 'node:translate', id, dx, dy })
     }, 50),
   )

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -49,6 +49,32 @@ export function randomBrightColor() {
   return `hsl(${h} ${s}% ${l}%)`
 }
 
+export function throttleTranslate(
+  fn: (id: string, dx: number, dy: number) => void,
+  ms: number,
+) {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const queue: Record<string, { dx: number; dy: number }> = {}
+
+  return (id: string, dx: number, dy: number) => {
+    if (!queue[id]) {
+      queue[id] = { dx: 0, dy: 0 }
+    }
+    queue[id].dx += dx
+    queue[id].dy += dy
+
+    if (!timer) {
+      timer = setTimeout(() => {
+        Object.entries(queue).forEach(([nid, delta]) => {
+          fn(nid, delta.dx, delta.dy)
+        })
+        timer = null
+        for (const key in queue) delete queue[key]
+      }, ms)
+    }
+  }
+}
+
 export function parseUrl(text = '') {
   const match = text.match(/^((data:|https?:)\/\/\S+)(\s+|<br\s*\/?>)??$/) // match URL followed by space or <br>
   return match ? match[1] || '' : ''


### PR DESCRIPTION
## Summary
- add `throttleTranslate` helper to combine rapid drag deltas
- use new helper when broadcasting node translations

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_b_686037cbb64c832f894804885dbd92e3