### PR TITLE
Fix realtime node updates

### DIFF
--- a/src/hooks/useRealtimeChannel.ts
+++ b/src/hooks/useRealtimeChannel.ts
@@ -18,7 +18,6 @@ function getClientId() {
 export type RealtimeAction =
   | { type: 'node:create'; node: CanvasNode }
   | { type: 'node:update'; id: string; props: Partial<CanvasNode> }
-  | { type: 'node:translate'; id: string; dx: number; dy: number }
   | { type: 'node:delete'; id: string }
   | { type: 'edge:create'; edge: CanvasEdge }
   | { type: 'edge:delete'; from: string; to: string }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -49,31 +49,6 @@ export function randomBrightColor() {
   return `hsl(${h} ${s}% ${l}%)`
 }
 
-export function throttleTranslate(
-  fn: (id: string, dx: number, dy: number) => void,
-  ms: number,
-) {
-  let timer: ReturnType<typeof setTimeout> | null = null
-  const queue: Record<string, { dx: number; dy: number }> = {}
-
-  return (id: string, dx: number, dy: number) => {
-    if (!queue[id]) {
-      queue[id] = { dx: 0, dy: 0 }
-    }
-    queue[id].dx += dx
-    queue[id].dy += dy
-
-    if (!timer) {
-      timer = setTimeout(() => {
-        Object.entries(queue).forEach(([nid, delta]) => {
-          fn(nid, delta.dx, delta.dy)
-        })
-        timer = null
-        for (const key in queue) delete queue[key]
-      }, ms)
-    }
-  }
-}
 
 export function parseUrl(text = '') {
   const match = text.match(/^((data:|https?:)\/\/\S+)(\s+|<br\s*\/?>)??$/) // match URL followed by space or <br>


### PR DESCRIPTION
## Summary
- simplify realtime protocol by removing `node:translate`
- send absolute coordinates in the debounced `node:update` event
- drop unused `throttleTranslate` helper

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_686043c89430832f9f52b9ada820316a