### PR TITLE
Add recent spaces

### DIFF
--- a/src/components/RecentSpaces.tsx
+++ b/src/components/RecentSpaces.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+import { makeUrl } from '../lib/url.js'
+import { getRecentSpaces } from '../lib/recent-spaces.js'
+import type { RecentSpace } from '../lib/recent-spaces.js'
+
+export function RecentSpaces() {
+  const [spaces, setSpaces] = useState<RecentSpace[]>([])
+
+  useEffect(() => {
+    setSpaces(getRecentSpaces().slice(0, 3))
+  }, [])
+
+  if (spaces.length === 0) return null
+
+  return (
+    <div className="RecentSpaces">
+      <h2>Recent spaces</h2>
+      <div className="Spaces_grid">
+        {spaces.map((space) => (
+          <div
+            key={space.id}
+            className="SpaceCardWrapper"
+            style={{ backgroundColor: space.backgroundColor }}
+          >
+            <a className="SpaceCard" href={makeUrl(space.id, space.title)}>
+              {space.title || 'Untitled'}
+            </a>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/board/Edge.tsx
+++ b/src/components/board/Edge.tsx
@@ -51,6 +51,10 @@ export const Edge = ({ fromNode, toNode, nodes, onDisconnect, toPosition }: Edge
   const from = useMemo(() => nodes.find((node) => node.id === fromNode), [fromNode, nodes])!
   const to = useMemo(() => nodes.find((node) => node.id === toNode), [toNode, nodes])!
 
+  const onClick = useCallback(() => {
+    onDisconnect(fromNode, toNode)
+  }, [fromNode, toNode, onDisconnect])
+
   if (!from || !to) {
     console.warn(`Edge from "${fromNode}" to "${toNode}" not found in nodes`, { from, to, nodes })
     return null
@@ -75,10 +79,6 @@ export const Edge = ({ fromNode, toNode, nodes, onDisconnect, toPosition }: Edge
     y2 = path.y2
     curve = path.curve
   }
-
-  const onClick = useCallback(() => {
-    onDisconnect(fromNode, toNode)
-  }, [fromNode, toNode, onDisconnect])
 
   return (
     <g className="Edge">

--- a/src/hooks/useInitApp.ts
+++ b/src/hooks/useInitApp.ts
@@ -5,6 +5,7 @@ import { useBeforeUnload } from './useBeforeUnload'
 import { randomId } from '../lib/utils'
 import { type useDocState } from './useDocState'
 import { useSession } from '@supabase/auth-helpers-react'
+import { addRecentSpace } from '../lib/recent-spaces.js'
 
 const TITLE = 'SpaceNotes'
 
@@ -67,6 +68,13 @@ export function useInitApp(state: ReturnType<typeof useDocState>) {
   useEffect(() => {
     document.body.style.backgroundColor = doc?.backgroundColor ?? ''
   }, [doc?.backgroundColor])
+
+  // Update recent spaces
+  useEffect(() => {
+    if (doc.id) {
+      addRecentSpace({ id: doc.id, title: doc.title, backgroundColor: doc.backgroundColor })
+    }
+  }, [doc.id, doc.title, doc.backgroundColor])
 
   // Fork current space
   const onFork = useCallback(() => {

--- a/src/lib/recent-spaces.ts
+++ b/src/lib/recent-spaces.ts
@@ -1,0 +1,22 @@
+export type RecentSpace = { id: string; title?: string; backgroundColor?: string }
+
+const KEY = 'spacenotes-recent-spaces'
+
+export function getRecentSpaces(): RecentSpace[] {
+  try {
+    const json = localStorage.getItem(KEY)
+    return json ? (JSON.parse(json) as RecentSpace[]) : []
+  } catch {
+    return []
+  }
+}
+
+export function addRecentSpace(space: RecentSpace) {
+  try {
+    const spaces = getRecentSpaces().filter((s) => s.id !== space.id)
+    spaces.unshift(space)
+    localStorage.setItem(KEY, JSON.stringify(spaces.slice(0, 10)))
+  } catch {
+    // ignore storage errors
+  }
+}

--- a/src/pages/SpacesPage.tsx
+++ b/src/pages/SpacesPage.tsx
@@ -1,4 +1,5 @@
 import { Spaces } from '../components/Spaces.js'
+import { RecentSpaces } from '../components/RecentSpaces.js'
 import { Header } from '../components/Header.js'
 import { Footer } from '../components/Footer.js'
 
@@ -7,6 +8,7 @@ export function SpacesPage() {
     <div className="SpacesView">
       <Header showLogout />
       <main className="SpacesView_main">
+        <RecentSpaces />
         <Spaces />
       </main>
       <Footer />

--- a/src/styles.css
+++ b/src/styles.css
@@ -674,6 +674,15 @@ button.Auth_textButton {
   padding: var(--space-l);
 }
 
+.RecentSpaces {
+  padding: var(--space-l);
+  padding-bottom: 0;
+}
+
+.RecentSpaces h2 {
+  margin-top: 0;
+}
+
 .Spaces_grid {
   margin: 0 auto;
   max-width: 1200px;


### PR DESCRIPTION
## Summary
- track recently opened spaces in localStorage
- show top three recent spaces above the spaces list
- expose helper to manage recent spaces
- update styling for new section
- fix a linter issue in Edge component

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_687e183f0d98832fbc944e3606c6146b