### PR TITLE
feat: enable real-time sessions with forking prompts

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -6,7 +6,7 @@ import { useDocument } from '../context/DocumentContext.js'
 
 export function Editor() {
   const state = useDocument()
-  const { doc, cursors, clientId, onCursorMove, onNodeCreate, onNodeDelete, onNodeUpdate, onConnect, onDisconnect, onBackgroundColorChange, onTitleChange, onFork, isLocked } = state
+  const { doc, cursors, clientId, onCursorMove, onNodeCreate, onNodeDelete, onNodeUpdate, onConnect, onDisconnect, onBackgroundColorChange, onTitleChange, onFork, isLocked, onShareSession, isOwner } = state
 
   return (
     <ImageDrop
@@ -17,7 +17,6 @@ export function Editor() {
     >
       <Board
         {...doc}
-        isLocked={isLocked}
         onNodeCreate={onNodeCreate}
         onNodeDelete={onNodeDelete}
         onNodeUpdate={onNodeUpdate}
@@ -36,6 +35,8 @@ export function Editor() {
         onTitleChange={onTitleChange}
         isLocked={isLocked}
         title={doc.title}
+        onShareSession={onShareSession}
+        isOwner={isOwner}
       />
     </ImageDrop>
   )

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -11,11 +11,13 @@ type SidebarProps = {
   title?: string
   onFork: () => void
   onTitleChange: (title: string) => void
+  onShareSession: () => void
+  isOwner?: boolean
 }
 
 const ITEMS_PER_PAGE = 10
 
-export function Sidebar({ isLocked, title, onFork, onTitleChange }: SidebarProps) {
+export function Sidebar({ isLocked, title, onFork, onTitleChange, onShareSession, isOwner }: SidebarProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [docs, setDocs] = useState([])
   const [page, setPage] = useState(1)
@@ -115,6 +117,9 @@ export function Sidebar({ isLocked, title, onFork, onTitleChange }: SidebarProps
             <a href={makeUrl(Math.random().toString(36).slice(2))}>
               <button>＋New space</button>
             </a>
+            {isOwner && (
+              <button onClick={onShareSession}>Share session</button>
+            )}
             {isLocked && <ForkButton onFork={onFork} />}
           </div>
         )}

--- a/src/hooks/useRealtimeChannel.ts
+++ b/src/hooks/useRealtimeChannel.ts
@@ -27,15 +27,15 @@ export type RealtimeAction =
   | { type: 'node:select'; ids: string[]; color: string }
 
 export function useRealtimeChannel(
-  docId: string,
+  roomId: string,
   handlers: { apply: (action: RealtimeAction, clientId: string) => void },
 ) {
   const channelRef = useRef<RealtimeChannel | null>(null)
   const clientId = useRef(getClientId())
 
   useEffect(() => {
-    if (!docId) return
-    const channel = supabase.channel(`space:${docId}`, {
+    if (!roomId) return
+    const channel = supabase.channel(`space:${roomId}`, {
       config: { broadcast: { self: false } },
     })
 
@@ -50,7 +50,7 @@ export function useRealtimeChannel(
     return () => {
       supabase.removeChannel(channel)
     }
-  }, [docId, handlers])
+  }, [roomId, handlers])
 
   const send = useCallback((action: RealtimeAction) => {
     channelRef.current?.send({


### PR DESCRIPTION
## Summary
- add Share session button to start collaborative sessions
- allow session-based real-time editing and prompt to fork on first edit if not in session

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_b_6899b9543580832fb7f02bce39478d40