### PR TITLE
fix: treat new spaces as owned

### DIFF
--- a/src/hooks/useInitApp.ts
+++ b/src/hooks/useInitApp.ts
@@ -16,7 +16,7 @@ export function useInitApp(state: ReturnType<typeof useDocState> & { sessionToke
   // Init user session
   const session = useSession()
   const userId = session?.user?.id || ''
-  const isOwner = doc.userId === userId
+  const isOwner = !doc.userId || doc.userId === userId
   const isLocked = !isOwner && !sessionToken
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid fork prompts for newly created spaces by treating blank ownership as current user

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_68b953ba11f8832f8eab5fcc08a00ef0