### PR TITLE
Ensure new notes retain focus

### DIFF
--- a/src/components/board/Board.tsx
+++ b/src/components/board/Board.tsx
@@ -81,11 +81,6 @@ export function Board(props: BoardProps) {
       y: mousePosition.y - 10,
       ...nodeProps,
     })
-    if (!node.content) {
-      setTimeout(() => {
-        document.getElementById(node.id)?.focus()
-      }, 100)
-    }
     return node
   }, [props.onNodeCreate, mousePosition.x, mousePosition.y])
 

--- a/src/components/board/Editable.tsx
+++ b/src/components/board/Editable.tsx
@@ -30,6 +30,13 @@ export const Editable = ({ id, content, width, height, onChange, onHeightChange 
   const [hasMinHeight, setHasMinHeight] = useState(!content && !isManualHeight)
   const [isFocused, setIsFocused] = useState(false)
 
+  useEffect(() => {
+    if (ref.current && !content) {
+      ref.current.focus()
+      setIsFocused(true)
+    }
+  }, [content])
+
   // Update height based on content changes
   const updateHeight = useCallback(() => {
     if (!isManualHeight && ref.current) {


### PR DESCRIPTION
## Summary
- Auto-focus editable content when a new note is created
- Simplify node creation logic now that editing handles focus

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_b_68b95465bf80832f8cf2d41dc9318d82