### PR TITLE
Fix negative size

### DIFF
--- a/src/components/board/DraggableNode.tsx
+++ b/src/components/board/DraggableNode.tsx
@@ -17,6 +17,8 @@ type DraggableNodeProps = CanvasNode & {
 }
 
 const BG_THRESHOLD = 110e3
+const MIN_WIDTH = 50
+const MIN_HEIGHT = 50
 
 const stopPropagation = (e) => e.stopPropagation()
 
@@ -85,8 +87,14 @@ export function DraggableNode(props: DraggableNodeProps) {
     (dx: number, dy: number) => {
       const oldSize = size.current
       const newSize = {
-        width: Math.round((oldSize.width || INITIAL_WIDTH) + dx),
-        height: Math.round((oldSize.height || INITIAL_HEIGHT) + dy),
+        width: Math.max(
+          Math.round((oldSize.width || INITIAL_WIDTH) + dx),
+          MIN_WIDTH
+        ),
+        height: Math.max(
+          Math.round((oldSize.height || INITIAL_HEIGHT) + dy),
+          MIN_HEIGHT
+        ),
       }
       props.onNodeUpdate(props.id, newSize)
       return newSize


### PR DESCRIPTION
## Problem

When dragging the resizer past the top-left corner of a card, width and height could become negative values, and thus the position of connected edges will be wrong.


https://github.com/user-attachments/assets/3ac22c98-3a48-45f9-ae42-b06058ffecd2


## Fix

Added `MIN_WIDTH` and `MIN_HEIGHT` on each node to avoid negative size values.
